### PR TITLE
feat(kill): Impl `kill` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
 name = "clap"
 version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +105,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "errno"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +137,7 @@ name = "hpm"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "which",
 ]
 
 [[package]]
@@ -116,6 +145,18 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "once_cell"
@@ -139,6 +180,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -169,6 +223,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
 
 [[package]]
 name = "windows-sys"
@@ -242,3 +308,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+which = "7.0.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,15 @@
+use std::io::Write;
+
 use clap::{Parser, Subcommand};
+
+use crate::{PROGRAM, process::Process};
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
 #[command(args_conflicts_with_subcommands = true)]
-struct Cli {
-    /// Select the subcommand interactively.
-    #[arg(short, long, group = "standalone")]
+struct Args {
+    /// Open interactive mode.
+    #[arg(short, long)]
     interactive: bool,
 
     #[command(subcommand)]
@@ -25,17 +29,45 @@ enum Command {
 }
 
 #[derive(Debug)]
-pub enum HpmError {}
+pub enum Error {
+    FailedToWriteStdout(std::io::Error),
+}
 
-impl std::fmt::Display for HpmError {
+impl std::error::Error for Error {}
+impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "will be implemented.")
+        match self {
+            Error::FailedToWriteStdout(err) => {
+                write!(f, "{}: failed to write to stdout: {}", PROGRAM, err)
+            }
+        }
     }
 }
 
-pub fn run() -> Result<(), HpmError> {
-    let cli = Cli::parse();
+pub fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
 
-    println!("{:?}", cli);
+    let mut process = if let Some(cmd) = args.command {
+        match cmd {
+            Command::Kill => kill(),
+            Command::Restart => todo!(),
+            Command::Logout => todo!(),
+        }
+    } else {
+        return Ok(());
+    };
+
+    let process_stdout = process.exec()?;
+
+    std::io::stdout()
+        .write_all(&process_stdout)
+        .map_err(Error::FailedToWriteStdout)?;
+
     Ok(())
+}
+
+fn kill() -> Process {
+    let mut cmd = std::process::Command::new("systemctl");
+    cmd.arg("poweroff");
+    Process::new(cmd)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub use cli::run;
 pub mod process;
 
 pub const PROGRAM: &str = "hpm";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod cli;
+pub mod process;
+
+pub const PROGRAM: &str = "hpm";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,29 @@
 use std::process::ExitCode;
 
-mod cli;
+use hpm::{cli, process};
 
 fn main() -> ExitCode {
-    match cli::run() {
+    match hpm::run() {
         Ok(_) => ExitCode::SUCCESS,
         Err(hpm_err) => {
             eprintln!("{hpm_err}");
-            ExitCode::FAILURE
+
+            if let Some(err) = hpm_err.downcast_ref::<process::Error>() {
+                return ExitCode::from(match err {
+                    process::Error::BinaryDoesNotExist(_) => 1u8,
+                    process::Error::FailedToExecProcess(_, _) => 1u8,
+                    process::Error::Exec(ecode, _) => ecode.to_owned(),
+                    process::Error::Interrupted => 130u8,
+                });
+            }
+
+            if let Some(err) = hpm_err.downcast_ref::<cli::Error>() {
+                return ExitCode::from(match err {
+                    cli::Error::FailedToWriteStdout(_) => 1u8,
+                });
+            }
+
+            ExitCode::from(2u8)
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,82 @@
+use std::{
+    ffi::{OsStr, OsString},
+    process::Command,
+};
+
+use crate::PROGRAM;
+
+#[derive(Debug)]
+pub enum Error {
+    BinaryDoesNotExist(OsString),
+    FailedToExecProcess(OsString, std::io::Error),
+    Exec(u8, Vec<u8>),
+    Interrupted,
+}
+
+impl std::error::Error for Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::BinaryDoesNotExist(binary) => {
+                write!(f, "{PROGRAM}: the binary does not exist: {:?}", binary)
+            }
+            Error::FailedToExecProcess(binary, error) => {
+                write!(
+                    f,
+                    "{PROGRAM}: failed to execute the binary {:?}: {}",
+                    binary, error
+                )
+            }
+            Error::Exec(_, vec) => {
+                let process_err = String::from_utf8(vec.to_owned())
+                    .expect("the process output should be valid UTF-8");
+
+                write!(f, "{PROGRAM}: {process_err}")
+            }
+            Error::Interrupted => {
+                write!(f, "{PROGRAM}: interrupted by the host")
+            }
+        }
+    }
+}
+
+pub struct Process(Command);
+impl Process {
+    fn new(cmd: Command) -> Self {
+        Self(cmd)
+    }
+
+    fn get_process_name(&self) -> &OsStr {
+        self.0.get_program()
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        let process_name = self.get_process_name();
+        which::which(process_name)
+            .map(|_| ())
+            .map_err(|_| Error::BinaryDoesNotExist(process_name.to_os_string()))
+    }
+
+    pub fn exec(&mut self) -> Result<Vec<u8>, Error> {
+        self.validate()?;
+
+        let proc_output = self
+            .0
+            .output()
+            .map_err(|err| Error::FailedToExecProcess(self.get_process_name().into(), err))?;
+
+        let ecode = proc_output.status.code().ok_or(Error::Interrupted)? as u8;
+
+        if proc_output.status.success() {
+            return Ok(proc_output.stdout);
+        }
+
+        Err(Error::Exec(ecode, proc_output.stderr))
+    }
+}
+
+pub fn kill() -> Process {
+    let mut cmd = Command::new("systemctl");
+    cmd.arg("poweroff");
+    Process::new(cmd)
+}


### PR DESCRIPTION
Kill subcommand is implemented by adding a new module `process` to the project.

This module contains the actual logic that is used by the `hpm` binary
crate.

The actual "kill" functionality is implemented by calling `systemctl
poweroff` (child process).

The child process' stdout stream is propagated to the inherited
`std::io::stdout()` stream.

The child process' stderr stream is propagated to the binary crate.

Potential errors from the entrypoint:

- `process::Error` signifies the potential errors that may arise from
interacting with child process.
- `cli:Error` signifies the potential errors that may arise during
child process' output propagation.

Dependencies:

The crate `which` is added to the project to validate the child
processes.