### PR TITLE
feat(release): Add release pipeline for `hpm`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: "hpm - Release"
+run-name: "hpm - Release on ${{ github.ref }}"
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GIT_TAG: ${{ github.ref_name }}
+
+jobs:
+  integrity_checks:
+    uses: ./.github/workflows/ci.yml
+
+  create_release:
+    runs-on: ubuntu-24.04
+    needs: integrity_checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create release
+        run: |
+          gh release "$GIT_TAG" --verify-tag --draft --title "$GIT_TAG"
+
+        shell: bash
+
+
+  archive:        
+    runs-on: ubuntu-24.04
+    needs: create_release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create release binary
+        env:
+          RUST_TARGET: "x86_64-unknown-linux-gnu"
+        run: |
+          ./exec build "$RUST_TARGET"
+          
+        shell: bash
+
+      - name: Archive release binary
+        id: create-archive
+        env:
+          RUST_TARGET: "x86_64-unknown-linux-gnu"
+        run: |
+          name="hpm-$RUST_TARGET-$GIT_TAG.tar.gz"
+          path="./target/$RUST_TARGET/release/$name"
+
+          ./exec create_archive "$RUST_TARGET" "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+
+      - name: Create checksum
+        id: create-checksum
+        env:
+          RUST_TARGET: "x86_64-unknown-linux-gnu"
+        run: |
+          name="hpm-$RUST_TARGET-$GIT_TAG.sha256sum"
+          path="./target/$RUST_TARGET/release/$name"
+
+          ./exec create_checksum "$RUST_TARGET" "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts to the release
+        env:
+          ARCHIVE_PATH: ${{ steps.create-archive.outputs.path }}
+          CHECKSUM_PATH: ${{ steps.create-checksum.outputs.path }}
+        run: |
+          gh release upload "$GIT_TAG" \
+            "$ARCHIVE_PATH" \
+            "$CHECKSUM_PATH"
+          
+        shell: bash
+
+      - name: Rollback release on failure
+        if: failure()
+        run: |
+          gh release delete "$GIT_TAG" -y --cleanup-tag        

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,20 @@
 [package]
 name = "hpm"
 version = "0.1.0"
+authors = ["Berk Acikgoz <acikgozb@proton.me>"]
 edition = "2024"
+description = "A simple, interactive program for host power management."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/acikgozb/hpm"
 
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 which = "7.0.0"
+
+[profile.release]
+lto = true
+strip = true
+# Size > comp time for this program, hence the codegen flag.
+codegen-units = 1

--- a/exec
+++ b/exec
@@ -23,4 +23,29 @@ function lint {
   cargo clippy --no-deps
 }
 
+function build {
+  check_extern_commands "cargo"
+
+  RUST_TARGET="${1:-x86_64-unknown-linux-gnu}"
+  cargo build --release --locked --target "$RUST_TARGET"
+}
+
+function create_archive {
+  check_extern_commands "tar"
+
+  RUST_TARGET="${1:-x86_64-unknown-linux-gnu}"
+  ARCHIVE_PATH="${2:-binary.tar.gz}"
+
+  tar -C "./target/$RUST_TARGET/release" -czvf "$ARCHIVE_PATH" "hpm"
+}
+
+function create_checksum {
+  check_extern_commands "sha256sum"
+
+  RUST_TARGET="${1:-x86_64-unknown-linux-gnu}"
+  CHECKSUM_PATH="${2:-binary.sha256sum}"
+
+  sha256sum "./target/$RUST_TARGET/release/hpm" > "$CHECKSUM_PATH"
+}
+
 "$@"


### PR DESCRIPTION
Pipeline flow:

- Does Integrity checks (`ci.yml` that is used in PRs),
- Creates a empty, draft GH release,
- Creates release artifacts: a binary archive and its checksum,
- Finally, uploads the artifacts to the draft release.

The actual scripts are put into the helper script `exec`.